### PR TITLE
Could uk.ac.ebi.fgpt:zooma-bootstrap:2.1.11-SNAPSHOT drop off redundant dependencies? 

### DIFF
--- a/zooma-bootstrap/pom.xml
+++ b/zooma-bootstrap/pom.xml
@@ -24,5 +24,14 @@
             </resource>
         </resources>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.5</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/170049006-328b2004-b640-43f7-8fc3-2eef3fcb01df.png)

This figure presents the dependency tree between multiple modules in **_zooma2_**. As shown in this figure, Library **_org.slf4j:jcl-over-slf4j:jar:1.7.5:compile_** in 
<module>zooma-spi</module>
        <module>zooma-api</module>
        <module>zooma-core</module>
        <module>zooma-impl</module>
        <module>zooma-owlapi</module>
        <module>zooma-jdbc</module>
        <module>zooma-lucene-services</module>
        <module>zooma-lodestar</module>
        <module>zooma-security</module>
        <module>zooma-loading</module>
        <module>zooma-bootstrap</module>
        <module>zooma-reporting</module>
        <module>zooma-client</module>
        <module>zooma-builder-app</module>
        <module>zooma-searcher-app</module>
        <module>zooma-ui</module>
        <module>zooma-ols-service</module>
        <module>zooma-integration-tests</module>

 is inherited from their parent module. However, it is not actually used by **_zooma-bootstrap_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in **_zooma-bootstrap_**.

Specifically, the scope of **_org.slf4j:jcl-over-slf4j:jar:1.7.5:compile_** in **_zooma-bootstrap_** can be changed from compile to provided. The revisions in the pom are described as follows:

![image](https://user-images.githubusercontent.com/78527112/170050036-65afacd0-aa16-46c2-900a-b4bfc2181c6b.png)

Best regards